### PR TITLE
Fix GB Printer compatibility with older printer revision

### DIFF
--- a/fs/js/script.js
+++ b/fs/js/script.js
@@ -948,8 +948,11 @@ function decodePrinterStatus(byte, ignoreBusyFull = false) {
     return errors.length ? errors.join(", ") : "OK";
 }
 
+let isPrintingActive = false;
+
 function pollPrinterStatus() {
     if (typeof currentMode !== 'undefined' && currentMode !== "printer") return;
+    if (isPrintingActive) return;
 
     // Trigger status update on firmware if in printer mode
     fetch('/print_chunk?done=1')
@@ -1184,6 +1187,7 @@ function sendChunkedData(binaryData, chunkSize = 256) {
     const overlay = document.getElementById("print-overlay");
     const statusText = document.getElementById("print-status-text");
 
+    isPrintingActive = true;
     if (printBtn) printBtn.style.display = "none";
     // Check current status before showing overlay
     fetch("/status.json")
@@ -1209,6 +1213,7 @@ function sendChunkedData(binaryData, chunkSize = 256) {
                 .then(() => fetch("/status.json"))
                 .then(res => res.json())
                 .then(statusData => {
+                    isPrintingActive = false;
                     if (printBtn) printBtn.style.display = "block";
                     // Note: overlay is managed by pollPrinterStatus from now on
                     const printerStatus = statusData.printer;
@@ -1224,6 +1229,7 @@ function sendChunkedData(binaryData, chunkSize = 256) {
                     }
                 })
                 .catch(err => {
+                    isPrintingActive = false;
                     console.error("Print failed", err);
                     if (printBtn) printBtn.style.display = "block";
                     if (overlay) overlay.style.display = "none";
@@ -1241,6 +1247,7 @@ function sendChunkedData(binaryData, chunkSize = 256) {
                 setTimeout(() => bufferNextPacket(index + 1), 50);
             })
             .catch(err => {
+                isPrintingActive = false;
                 console.error("Buffer failed at packet " + index, err);
             });
     }

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -49,12 +49,12 @@
 
 #define TCP_MSS                         (1500 /*mtu*/ - 20 /*iphdr*/ - 20 /*tcphhr*/)
 #define TCP_SND_BUF                     (2 * TCP_MSS)
-#define TCP_WND                         (TCP_MSS)
+#define TCP_WND                         (2 * TCP_MSS)
 
 #define ETHARP_SUPPORT_STATIC_ENTRIES   1
 
 #define LWIP_HTTPD_CGI                  1
-#define LWIP_HTTPD_MAX_REQUEST_URI_LEN  1024
+#define LWIP_HTTPD_MAX_REQUEST_URI_LEN  1400
 //#define LWIP_HTTPD_CGI_SSI              1
 //#define LWIP_HTTPD_FILE_STATE           1
 

--- a/src/pico_gb_printer.c
+++ b/src/pico_gb_printer.c
@@ -559,7 +559,7 @@ void printer_send_packet(const uint8_t* packet, int length) {
         current_printer_status = PRINTER_STATUS_DISCONNECTED;
     }
 
-    sleep_us(200);
+    sleep_us(400);
     // Leave SCK HIGH (as printer_send_byte left it) — do NOT pull LOW or re-enable PIO.
     // A spurious falling edge would desync the printer.
     // PIO re-enabled only when JS sends done=1.
@@ -603,13 +603,59 @@ const char *cgi_print_chunk(int iIndex, int iNumParams, char *pcParam[], char *p
             static const uint8_t status_packet[] = {0x88, 0x33, 0x0f, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00};
             printer_send_packet(status_packet, sizeof(status_packet));
         } else {
-            // Send ALL buffered packets in one burst (like hello_usb.c)
+            // Collect all DATA payloads and reassemble into 640-byte strips.
+            // The GB Printer requires exactly 640-byte DATA packets (2 tile rows).
+            // HTTP chunks may be smaller (e.g. 256 bytes), so we reassemble here.
+            #define GB_STRIP_SIZE 640
+            #define GB_MAX_IMAGE  (9 * GB_STRIP_SIZE)
+            static uint8_t data_accum[GB_MAX_IMAGE];
+            int data_total = 0;
+
+            // Find index range of non-zero DATA packets
+            int first_data = -1, last_data = -1;
             for (int p = 0; p < pkt_queue_count; p++) {
-                printer_send_packet(
-                    &pkt_queue_buf[pkt_queue_offsets[p]],
-                    pkt_queue_lengths[p]
-                );
+                uint8_t *pkt = &pkt_queue_buf[pkt_queue_offsets[p]];
+                int     len  = pkt_queue_lengths[p];
+                if (len >= 10 && pkt[0] == 0x88 && pkt[1] == 0x33 && pkt[2] == 0x04) {
+                    int dlen = pkt[4] | (pkt[5] << 8);
+                    if (dlen > 0) {
+                        if (first_data < 0) first_data = p;
+                        last_data = p;
+                        if (data_total + dlen <= GB_MAX_IMAGE)
+                            memcpy(data_accum + data_total, pkt + 6, dlen);
+                        data_total += dlen;
+                    }
+                }
             }
+
+            // Send packets before the first DATA packet (INIT, STATUS)
+            int pre_end = (first_data >= 0) ? first_data : pkt_queue_count;
+            for (int p = 0; p < pre_end; p++)
+                printer_send_packet(&pkt_queue_buf[pkt_queue_offsets[p]], pkt_queue_lengths[p]);
+
+            // Send reassembled 640-byte DATA strips
+            for (int offset = 0; offset < data_total; offset += GB_STRIP_SIZE) {
+                int chunk = data_total - offset;
+                if (chunk > GB_STRIP_SIZE) chunk = GB_STRIP_SIZE;
+
+                uint8_t strip[GB_STRIP_SIZE + 10];
+                strip[0] = 0x88; strip[1] = 0x33; strip[2] = 0x04; strip[3] = 0x00;
+                strip[4] = chunk & 0xFF; strip[5] = (chunk >> 8) & 0xFF;
+                memcpy(strip + 6, data_accum + offset, chunk);
+
+                uint16_t chk = 0x04 + (chunk & 0xFF) + ((chunk >> 8) & 0xFF);
+                for (int i = 0; i < chunk; i++) chk += data_accum[offset + i];
+                strip[6 + chunk] = chk & 0xFF;
+                strip[7 + chunk] = (chk >> 8) & 0xFF;
+                strip[8 + chunk] = 0x00; strip[9 + chunk] = 0x00;
+
+                printer_send_packet(strip, chunk + 10);
+            }
+
+            // Send packets after the last DATA packet (DATA_END, PRINT, STATUS)
+            int post_start = (last_data >= 0) ? last_data + 1 : 0;
+            for (int p = post_start; p < pkt_queue_count; p++)
+                printer_send_packet(&pkt_queue_buf[pkt_queue_offsets[p]], pkt_queue_lengths[p]);
         }
         // Reset queue
         pkt_queue_count = 0;


### PR DESCRIPTION
The older printer revision requires 640-byte DATA packets (one full tile strip) and rejects smaller chunks. The adapter was sending 256-byte HTTP chunks which were forwarded as-is to the printer, causing checksum errors and garbled/missing output on the older hardware.

Firmware now reassembles incoming 256-byte DATA chunks into proper 640-byte strips before transmitting to the printer, while keeping HTTP requests small to avoid lwIP URI length limits.

Also fix a race condition where the periodic pollPrinterStatus() call (every 3s) could fire mid-buffer and trigger a premature burst send, causing partial prints. An isPrintingActive flag now blocks the poll during the full print sequence.

Increase LWIP_HTTPD_MAX_REQUEST_URI_LEN to 1400 and TCP_WND to 2*TCP_MSS as general robustness improvements for the HTTP server.